### PR TITLE
Populate includes field in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino library to control Grove 6 Axis Accelerometer&Gyroscope LSM6DS
 category=Sensors
 url=https://github.com/Seeed-Studio/Accelerometer_And_Gyroscope_LSM6DS3
 architectures=*
-includes=
+includes=SparkFunLSM6DS3.h


### PR DESCRIPTION
The includes field in library.properties is used to specify which #include directives should be added to the sketch via Sketch > Include Library > LIBRARYNAME. Leaving this field empty causes that action to add the following line to the sketch:

#include <>

which results in a compilation error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format